### PR TITLE
Change option-key in capabiliteis to comma-separated

### DIFF
--- a/src/Dhl/resources/capabilities.php
+++ b/src/Dhl/resources/capabilities.php
@@ -57,14 +57,10 @@ return array(
                         ),
                     'option' =>
                         array(
-                            'description' => 'The shipment options',
-                            'type' => 'array',
+                            'description' => 'The shipment options (comma separated)',
+                            'type' => 'string',
                             'required' => false,
-                            'location' => 'query',
-                            'items' =>
-                                array(
-                                    'type' => 'string',
-                                ),
+                            'location' => 'query'
                         ),
                     'fromPostalCode' =>
                         array(


### PR DESCRIPTION
Changed the option-key in the capabilities call to a string. From now the options needs to be given as a comma-separated string. For example: DOOR,EVE